### PR TITLE
Fixed bug; click outside list item now takes us out of edit mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -279,7 +279,15 @@ function onClickItem(e) {
       changeQuantityInStorageOf(itemText, e.target.value);
     }
   } else {
-    setItemToEdit(e.target);
+    if (e.target == itemList) {
+      // a click on the list itself; take every list item out of edit mode
+      itemList
+        .querySelectorAll('li')
+        .forEach((eachItem) => eachItem.classList.remove('edit-mode'));
+      isEditMode = false;
+    } else {
+      setItemToEdit(e.target);
+    }
   }
   resetUI();
 }


### PR DESCRIPTION
A click inside the itemList (ul) but outside a list item (li) would cause the textContent of the entire list (all of the items) to go to the item input form. Fixed it so that such a click now takes the application out of edit mode. 